### PR TITLE
Draft: Add 3Column-Tall layout variants

### DIFF
--- a/Amethyst/Layout/Layouts/ThreeColumnLayout.swift
+++ b/Amethyst/Layout/Layouts/ThreeColumnLayout.swift
@@ -90,6 +90,9 @@ struct TriplePaneArrangement {
 
         // calculate widths
         let screenWidth = screenSize.width
+        let mainPaneWidth = secondaryPaneCount == 0
+            ? screenWidth
+            : round(screenWidth * mainPaneRatio)
         let mainWindowWidth = mainPaneStack == Stack.tall
             ? round(mainPaneWidth/CGFloat(mainPaneCount))
             : mainPaneWidth

--- a/Amethyst/Layout/Layouts/ThreeColumnLayout.swift
+++ b/Amethyst/Layout/Layouts/ThreeColumnLayout.swift
@@ -39,7 +39,7 @@ struct TriplePaneArrangement {
 
     /// width of windows in pane
     private let paneWindowWidth: [Pane: CGFloat]
-    
+
     /// width of main pane (different than window in pane when using Stack.tall)
     private let mainPaneWidth: CGFloat
 
@@ -81,7 +81,7 @@ struct TriplePaneArrangement {
         // calculate heights
         let screenHeight = screenSize.height
         self.paneWindowHeight = [
-            .main: mainPaneStack == Stack.tall 
+            .main: mainPaneStack == Stack.tall
                 ? screenHeight
                 : round(screenHeight / CGFloat(mainPaneCount)),
             .secondary: secondaryPaneCount == 0 ? 0.0 : round(screenHeight / CGFloat(secondaryPaneCount)),
@@ -226,7 +226,7 @@ class ThreeColumnLayout<Window: WindowType>: Layout<Window> {
                 case .right: return leftPaneWidth + middlePaneWidth
                 }
             }()
-                                   
+
             let yorigin: CGFloat = screenFrame.origin.y + {
                 switch column {
                 case .left:
@@ -327,4 +327,3 @@ class ThreeColumnTallRightLayout<Window: WindowType>: ThreeColumnLayout<Window>,
     override static var mainColumn: Column { return .right }
     override static var mainColumnStack: Stack { return .tall }
 }
-

--- a/Amethyst/Managers/LayoutType.swift
+++ b/Amethyst/Managers/LayoutType.swift
@@ -20,6 +20,9 @@ enum LayoutType<Window: WindowType>: String, CaseIterable {
     case threeColumnLeft = "3column-left"
     case threeColumnMiddle = "middle-wide"
     case threeColumnRight = "3column-right"
+    case threeColumnTallLeft = "3column-tall-left"
+    case threeColumnTallMiddle = "3column-tall-middle"
+    case threeColumnTallRight = "3column-tall-right"
     case fullscreen = "fullscreen"
     case column = "column"
     case row = "row"
@@ -44,6 +47,12 @@ enum LayoutType<Window: WindowType>: String, CaseIterable {
             return ThreeColumnMiddleLayout<Window>.self
         case .threeColumnRight:
             return ThreeColumnRightLayout<Window>.self
+        case .threeColumnLeft:
+            return ThreeColumnTallLeftLayout<Window>.self
+        case .threeColumnMiddle:
+            return ThreeColumnTallMiddleLayout<Window>.self
+        case .threeColumnRight:
+            return ThreeColumnTallRightLayout<Window>.self
         case .fullscreen:
             return FullscreenLayout<Window>.self
         case .column:
@@ -116,6 +125,12 @@ enum LayoutType<Window: WindowType>: String, CaseIterable {
             return try JSONEncoder().encode(typedLayout)
         case let typedLayout as ThreeColumnRightLayout<Window>:
             return try JSONEncoder().encode(typedLayout)
+        case let typedLayout as ThreeColumnTallLeftLayout<Window>:
+            return try JSONEncoder().encode(typedLayout)
+        case let typedLayout as ThreeColumnTallMiddleLayout<Window>:
+            return try JSONEncoder().encode(typedLayout)
+        case let typedLayout as ThreeColumnTallRightLayout<Window>:
+            return try JSONEncoder().encode(typedLayout)
         case let typedLayout as FullscreenLayout<Window>:
             return try JSONEncoder().encode(typedLayout)
         case let typedLayout as ColumnLayout<Window>:
@@ -157,6 +172,12 @@ enum LayoutType<Window: WindowType>: String, CaseIterable {
             return try decoder.decode(ThreeColumnMiddleLayout.self, from: data)
         case .threeColumnRight:
             return try decoder.decode(ThreeColumnRightLayout.self, from: data)
+        case .threeColumnTallLeft:
+            return try decoder.decode(ThreeColumnTallLeftLayout.self, from: data)
+        case .threeColumnTallMiddle:
+            return try decoder.decode(ThreeColumnTallMiddleLayout.self, from: data)
+        case .threeColumnTallRight:
+            return try decoder.decode(ThreeColumnTallRightLayout.self, from: data)
         case .fullscreen:
             return try decoder.decode(FullscreenLayout.self, from: data)
         case .column:

--- a/Amethyst/Managers/LayoutType.swift
+++ b/Amethyst/Managers/LayoutType.swift
@@ -47,11 +47,11 @@ enum LayoutType<Window: WindowType>: String, CaseIterable {
             return ThreeColumnMiddleLayout<Window>.self
         case .threeColumnRight:
             return ThreeColumnRightLayout<Window>.self
-        case .threeColumnLeft:
+        case .threeColumnTallLeft:
             return ThreeColumnTallLeftLayout<Window>.self
-        case .threeColumnMiddle:
+        case .threeColumnTallMiddle:
             return ThreeColumnTallMiddleLayout<Window>.self
-        case .threeColumnRight:
+        case .threeColumnTallRight:
             return ThreeColumnTallRightLayout<Window>.self
         case .fullscreen:
             return FullscreenLayout<Window>.self

--- a/AmethystTests/Tests/Layout/ThreeColumnLayoutTests.swift
+++ b/AmethystTests/Tests/Layout/ThreeColumnLayoutTests.swift
@@ -80,6 +80,7 @@ class ThreeColumnLayoutTests: QuickSpec {
                 let height: (UInt, Pane) -> CGFloat = { windowCount, pane -> CGFloat in
                     return TriplePaneArrangement(
                         mainPane: .left,
+                        mainPaneStack: .wide,
                         numWindows: windowCount,
                         numMainPane: mainPaneCount,
                         screenSize: screenSize,
@@ -103,7 +104,7 @@ class ThreeColumnLayoutTests: QuickSpec {
                 expect(height(5, .tertiary)).to(equal(1000))
                 expect(height(6, .tertiary)).to(equal(500))
             }
-            
+
             it("splits panes into columns on tall variant") {
                 let mainPaneCount: UInt = 2
                 let screenSize = CGSize(width: 2000, height: 1000)
@@ -117,10 +118,26 @@ class ThreeColumnLayoutTests: QuickSpec {
                         mainPaneRatio: 0.5
                     ).height(pane)
                 }
+                let width: (UInt, Pane) -> CGFloat = { windowCount, pane -> CGFloat in
+                    return TriplePaneArrangement(
+                        mainPane: .left,
+                        mainPaneStack: .tall,
+                        numWindows: windowCount,
+                        numMainPane: mainPaneCount,
+                        screenSize: screenSize,
+                        mainPaneRatio: 0.5
+                    ).width(pane)
+                }
 
                 expect(height(1, .main)).to(equal(1000))
-                expect(height(2, .main)).to(equal(500))
-                expect(height(3, .main)).to(equal(500))
+                expect(width(1, .main)).to(equal(2000))
+                expect(height(2, .main)).to(equal(1000))
+                expect(width(2, .main)).to(equal(1000))
+                expect(height(3, .main)).to(equal(1000))
+                expect(width(3, .main)).to(equal(500))
+                expect(height(4, .main)).to(equal(1000))
+                expect(width(4, .main)).to(equal(500))
+
                 expect(height(1, .secondary)).to(equal(0))
                 expect(height(2, .secondary)).to(equal(0))
                 expect(height(3, .secondary)).to(equal(1000))

--- a/AmethystTests/Tests/Layout/ThreeColumnLayoutTests.swift
+++ b/AmethystTests/Tests/Layout/ThreeColumnLayoutTests.swift
@@ -25,6 +25,7 @@ class ThreeColumnLayoutTests: QuickSpec {
                     let count: (UInt) -> UInt = { windowCount -> UInt in
                         return TriplePaneArrangement(
                             mainPane: .left,
+                            mainPaneStack: .wide,
                             numWindows: windowCount,
                             numMainPane: mainPaneCount,
                             screenSize: screenSize,
@@ -43,6 +44,7 @@ class ThreeColumnLayoutTests: QuickSpec {
                     let secondaryCount: (UInt) -> UInt = { windowCount -> UInt in
                         return TriplePaneArrangement(
                             mainPane: .left,
+                            mainPaneStack: .wide,
                             numWindows: windowCount,
                             numMainPane: mainPaneCount,
                             screenSize: screenSize,
@@ -52,6 +54,7 @@ class ThreeColumnLayoutTests: QuickSpec {
                     let tertiaryCount: (UInt) -> UInt = { windowCount -> UInt in
                         return TriplePaneArrangement(
                             mainPane: .left,
+                            mainPaneStack: .wide,
                             numWindows: windowCount,
                             numMainPane: mainPaneCount,
                             screenSize: screenSize,
@@ -77,6 +80,37 @@ class ThreeColumnLayoutTests: QuickSpec {
                 let height: (UInt, Pane) -> CGFloat = { windowCount, pane -> CGFloat in
                     return TriplePaneArrangement(
                         mainPane: .left,
+                        numWindows: windowCount,
+                        numMainPane: mainPaneCount,
+                        screenSize: screenSize,
+                        mainPaneRatio: 0.5
+                    ).height(pane)
+                }
+
+                expect(height(1, .main)).to(equal(1000))
+                expect(height(2, .main)).to(equal(500))
+                expect(height(3, .main)).to(equal(500))
+                expect(height(1, .secondary)).to(equal(0))
+                expect(height(2, .secondary)).to(equal(0))
+                expect(height(3, .secondary)).to(equal(1000))
+                expect(height(4, .secondary)).to(equal(1000))
+                expect(height(5, .secondary)).to(equal(500))
+                expect(height(6, .secondary)).to(equal(500))
+                expect(height(1, .tertiary)).to(equal(0))
+                expect(height(2, .tertiary)).to(equal(0))
+                expect(height(3, .tertiary)).to(equal(0))
+                expect(height(4, .tertiary)).to(equal(1000))
+                expect(height(5, .tertiary)).to(equal(1000))
+                expect(height(6, .tertiary)).to(equal(500))
+            }
+            
+            it("splits panes into columns on tall variant") {
+                let mainPaneCount: UInt = 2
+                let screenSize = CGSize(width: 2000, height: 1000)
+                let height: (UInt, Pane) -> CGFloat = { windowCount, pane -> CGFloat in
+                    return TriplePaneArrangement(
+                        mainPane: .left,
+                        mainPaneStack: .tall,
                         numWindows: windowCount,
                         numMainPane: mainPaneCount,
                         screenSize: screenSize,


### PR DESCRIPTION
Add 3Column-Tall layout variants, based off the 3Column layout but the main pane is split vertically (like Tall splits the screen).


https://user-images.githubusercontent.com/8604926/123744770-6b9ebc80-d8d9-11eb-936c-6cfa182efb24.mp4

Requesting comments on:
- Currently I'm implementing it by adding a `Stack` variant into the 3Column layout. Please let me know if this adds too much complexity.
- The name. Is 3Column Tall descriptive enough?

Draft tasks:
- [x] Modify ThreeColumnLayout to accept and work with `mainColumnStack` specification
- [ ] register the layout on `LayoutType.swift`
- [ ] Add tests regarding the Tall variants 